### PR TITLE
Review & merge ' java method for Python math.floor TDD' & tests

### DIFF
--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -30,7 +30,15 @@ public class math extends org.python.types.Module {
         double javaFloorArg;
 
         if (pyFloorArg instanceof org.python.types.Float) {
-            javaFloorArg = (double)((org.python.types.Float) pyFloorArg.__float__()).value;
+            javaFloorArg = ((org.python.types.Float) pyFloorArg.__float__()).value;
+
+            if (javaFloorArg == Double.POSITIVE_INFINITY) {
+                throw new org.python.exceptions.OverflowError("Python cannot convert float infinity to integer");
+            }
+
+            if (javaFloorArg != javaFloorArg) {
+                throw new org.python.exceptions.ValueError("Python cannot convert float NaN to integer");
+            }
         } else {
             throw new org.python.exceptions.TypeError("Floor not fully implemented yet; doesn't accept type " +
                 pyFloorArg.typeName() + ")");

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -23,7 +23,7 @@ public class math extends org.python.types.Module {
     @org.python.Method(
         __doc__ = "floor(pyFloorArg: number) -> integer\n" +
             "\n" +
-            "Returns the greatest interger less than or equal to a real number value input\n",
+            "Returns the greatest integer less than or equal to a real number value input\n",
         args = {"pyFloorArg"}
     )
     public static org.python.Object floor(org.python.Object pyFloorArg) {
@@ -32,7 +32,7 @@ public class math extends org.python.types.Module {
         if (pyFloorArg instanceof org.python.types.Float) {
             javaFloorArg = ((org.python.types.Float) pyFloorArg.__float__()).value;
 
-            if (javaFloorArg == Double.POSITIVE_INFINITY) {
+            if (javaFloorArg == Double.POSITIVE_INFINITY || javaFloorArg == Double.NEGATIVE_INFINITY) {
                 throw new org.python.exceptions.OverflowError("Python cannot convert float infinity to integer");
             }
 

--- a/python/common/python/math.java
+++ b/python/common/python/math.java
@@ -1,23 +1,40 @@
 package python;
 import java.lang.Math;
+
 @org.python.Module(
-        __doc__ =
-            "This is a math module for python" 
+    __doc__ =
+        "This is a math module for python"
 )
 public class math extends org.python.types.Module {
     public math() {
-        //super();
     }
 
     @org.python.Method(
-            __doc__ = "Returns a new subclass of tuple with named fields.\n" +
-                "\n",
-            args = {"x"}
+        __doc__ = "Returns a new subclass of tuple with named fields.\n" +
+            "\n",
+        args = {"x"}
     )
     public static double ceil(org.python.Object x) {
         double d =((org.python.types.Float) x.__float__()).value;
         return Math.ceil(d);//Math.ceil(d);
         //throw new org.python.exceptions.NotImplementedError("Ceil not implemented yet.");
     }
-    
+
+    @org.python.Method(
+        __doc__ = "floor(pyFloorArg: number) -> integer\n" +
+            "\n" +
+            "Returns the greatest interger less than or equal to a real number value input\n",
+        args = {"pyFloorArg"}
+    )
+    public static org.python.Object floor(org.python.Object pyFloorArg) {
+        double javaFloorArg;
+
+        if (pyFloorArg instanceof org.python.types.Float) {
+            javaFloorArg = (double)((org.python.types.Float) pyFloorArg.__float__()).value;
+        } else {
+            throw new org.python.exceptions.TypeError("Floor not fully implemented yet; doesn't accept type " +
+                pyFloorArg.typeName() + ")");
+        }
+        return org.python.types.Int.getInt((int)Math.floor(javaFloorArg));
+    }
 }

--- a/stdlib_tests/test_math.py
+++ b/stdlib_tests/test_math.py
@@ -1,0 +1,8 @@
+from math import floor
+print(floor(16.66))  # expected output: 16
+print(floor(-19.2))  # expected output: 20
+
+#print(floor(float("Infinity")))  # expected output: OverflowError: Python cannot convert float infinity to integer
+#print(floor(float("-Infinity")))  # expected output: OverflowError: Python cannot convert float infinity to integer
+
+#print(floor(float("nan")))  #  expected output: ValueError: Python cannot convert float NaN to integer

--- a/tests/stdlib/test_math.py
+++ b/tests/stdlib/test_math.py
@@ -1,9 +1,9 @@
 from unittest import expectedFailure
 
-from ..utils import TranspileTestCase, NotImplementedToExpectedFailure
+from ..utils import TranspileTestCase
 
 
-class MathModuleTests(TranspileTestCase, NotImplementedToExpectedFailure):
+class MathModuleTests(TranspileTestCase):
     """
     Testing of Python3 math module methods with TranspileTestCase:
         * math.floor
@@ -27,6 +27,14 @@ class MathModuleTests(TranspileTestCase, NotImplementedToExpectedFailure):
             test_arg = "str"
             print(floor(test_arg))
             """)
+
+    @expectedFailure
+    def test_math_floor_NaN_argument(self):
+        self.assertCodeExecution("""
+                from math import floor
+                test_arg = float("nan")
+                print(floor(test_arg))
+                """)
 
     @expectedFailure
     def test_math_floor_inf_argument(self):


### PR DESCRIPTION
Review:
* java method for Python math.floor TDD
    - fix failing test: 'test_math_floor_float_argument'
    - fix passing @expectFailure test: 'test_math_floor_NaN_argument'
    - fix passing @expectFailure test: 'test_math_floor_inf_argument'
* new math.floor test for NaN input
* math.floor test in stdlib_tests for float inputs

Merge to SprintOneTeamOne

Note: commit '6105ad4' message should be:
'Implement java method for Python math.floor TDD...'